### PR TITLE
Specify mustInclude based on selected line

### DIFF
--- a/frontend/src/Editor.jsx
+++ b/frontend/src/Editor.jsx
@@ -569,18 +569,19 @@ const Editor = ({ keyWord }) => {
               Un-exclude Word
             </Button>
           )}
-          {selectedWord && (
+          {selectedLineId !== null && lines[selectedLineId] && lines[selectedLineId].length > 0 && (
             <Button
               onClick={async () => {
                 // Generate grams (anagrams) when a word is selected.
                 const vocabUnion = Array.from(new Set([...commonWords, ...manyWords])).filter(
                   (w) => !excludedWords.includes(w)
                 );
+                const mustInclude = lines[selectedLineId];
                 const anagrams = [];
                 for await (const phrase of genAnagrams({
                   key: keyWord,
                   vocab: vocabUnion,
-                  mustInclude: [selectedWord],
+                  mustInclude,
                 })) {
                   anagrams.push(phrase);
                 }


### PR DESCRIPTION
gh-16

It's more useful to be able to narrow the gram set using multiple words. Rather than have a separate button like "must include these words," use the selected line, which is already a set of words that you want to include in your grams.